### PR TITLE
add keywords *distance* to Isochrone.isochrone and fix a bug

### DIFF
--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -279,6 +279,13 @@ class Isochrone(object):
         :param return_df: (optional)
             Whether to return a :class:``pandas.DataFrame`` or dictionary.  Default is ``True``.
         
+        :param distance:
+            Distance in pc.  If passed, then mags will be converted to
+            apparent mags based on distance (and ``AV``).
+
+        :param AV:
+            V-band extinction (magnitudes).            
+        
         :return:
             :class:`pandas.DataFrame` or dictionary containing results.
         

--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -166,8 +166,8 @@ class Isochrone(object):
             bands = self.bands
         mags = {band:self.mag[band](*args) for band in bands}
         if distance is not None:
+            dm = 5*np.log10(distance) - 5
             for band in mags:
-                dm = 5*np.log10(distance) - 5
                 A = AV*EXTINCTION[band]
                 mags[band] = mags[band] + dm + A
         

--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -165,9 +165,15 @@ class Isochrone(object):
         if bands is None:
             bands = self.bands
         mags = {band:self.mag[band](*args) for band in bands}
+        if distance is not None:
+            for band in mags:
+                dm = 5*np.log10(distance) - 5
+                A = AV*EXTINCTION[band]
+                mags[band] = mags[band] + dm + A
         
         props = {'age':age,'mass':Ms,'radius':Rs,'logL':logLs,
                 'logg':loggs,'Teff':Teffs,'mag':mags}        
+                
         if not return_df:
             return props
         else:
@@ -175,12 +181,7 @@ class Isochrone(object):
             for key in props.keys():
                 if key=='mag':
                     for m in props['mag'].keys():
-                        mag = props['mag'][m]
-                        if distance is not None:
-                            dm = 5*np.log10(distance) - 5
-                            A = AV*EXTINCTION[m]
-                            mag = mag + dm + A
-                        d['{}_mag'.format(m)] = mag
+                        d['{}_mag'.format(m)] = props['mag'][m]
                 else:
                     d[key] = props[key]
             try:

--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -260,7 +260,7 @@ class Isochrone(object):
 
             
     def isochrone(self,age,feh=0.0,minm=None,maxm=None,dm=0.02,
-                  return_df=True):
+                  return_df=True,distance=None):
         """
         Returns stellar models at constant age and feh, for a range of masses
 
@@ -298,6 +298,11 @@ class Isochrone(object):
         mags = {band:self.mag[band](ms,ages,feh) for band in self.bands}
         #for band in self.bands:
         #    mags[band] = self.mag[band](ms,ages)
+        if distance is not None:
+            dm = 5*np.log10(distance) - 5
+            for band in mags:
+                A = AV*EXTINCTION[band]
+                mags[band] = mags[band] + dm + A
 
         props = {'M':Ms,'R':Rs,'logL':logLs,'logg':loggs,
                 'Teff':Teffs,'mag':mags}        

--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -260,7 +260,7 @@ class Isochrone(object):
 
             
     def isochrone(self,age,feh=0.0,minm=None,maxm=None,dm=0.02,
-                  return_df=True,distance=None):
+                  return_df=True,distance=None,AV=0.0):
         """
         Returns stellar models at constant age and feh, for a range of masses
 


### PR DESCRIPTION
1. Fix a bug in **Isochrone.__call__**
    **props** is returned before distance module and extinction correction when keywords **return_df=False**, and so the returned results are not the same when specifying  **return_df** or not.

2. Add keywords **distance** to **Isochrone.isochrone**
    It would be handy to have keywords `distance` in method  isochrone too, eg. for stellar clusters.

3. keywords **distance** doesn't work for **bol** band (in both function above)
    Note that **data/extinction.txt** doesn't contain **bol**, the keywords **distance** won't work properly when **bol** present in **self.bands**. That might be a problem. 
    I don't know what's the proper solution as I'm not familar with observation things. Maybe we can add a assertion to make sure  **bol** and **distance** won't present at the same time.

PS
It seems I should put these things (bug fix and new keywords) in two pull requests. Sorry for possible inconvenience.