### PR TITLE
python3 compatibility

### DIFF
--- a/isochrones/basti.py
+++ b/isochrones/basti.py
@@ -19,19 +19,19 @@ TRI_FILE = '{}/basti.tri'.format(DATADIR)
 
 def _download_h5():
     url = 'http://zenodo.org/record/12800/files/basti.h5'
-    import urllib
+    from six.moves import urllib
     print('Downloading BASTI stellar model data (should happen only once)...')
     if os.path.exists(MASTERFILE):
         os.remove(MASTERFILE)
-    urllib.urlretrieve(url,MASTERFILE)
+    urllib.request.urlretrieve(url,MASTERFILE)
 
 def _download_tri():
     url = 'http://zenodo.org/record/12800/files/basti.tri'
-    import urllib
+    from six.moves import urllib
     print('Downloading BASTI isochrone pre-computed triangulation (should happen only once...)')
     if os.path.exists(TRI_FILE):
         os.remove(TRI_FILE)
-    urllib.urlretrieve(url,TRI_FILE)
+    urllib.request.urlretrieve(url,TRI_FILE)
 
 if not os.path.exists(MASTERFILE):
     _download_h5()
@@ -55,9 +55,14 @@ class Basti_Isochrone(Isochrone):
     def __init__(self):
         df = MASTERDF
 
-        f = open(TRI_FILE,'rb')
-        tri = pickle.load(f)
-        f.close()
+        try:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f)
+        except:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f,encoding='latin-1')
+        finally:
+            f.close()
 
         mags = {}
 

--- a/isochrones/dartmouth.py
+++ b/isochrones/dartmouth.py
@@ -33,11 +33,11 @@ def _download_h5():
     """
     #url = 'http://zenodo.org/record/12800/files/dartmouth.h5'
     url = 'http://zenodo.org/record/15843/files/dartmouth.h5'
-    import urllib
+    from six.moves import urllib
     print('Downloading Dartmouth stellar model data (should happen only once)...')
     if os.path.exists(MASTERFILE):
         os.remove(MASTERFILE)
-    urllib.urlretrieve(url,MASTERFILE)
+    urllib.request.urlretrieve(url,MASTERFILE)
 
 def _download_tri():
     """
@@ -46,11 +46,11 @@ def _download_tri():
     #url = 'http://zenodo.org/record/12800/files/dartmouth.tri'
     #url = 'http://zenodo.org/record/15843/files/dartmouth.tri'
     url = 'http://zenodo.org/record/17627/files/dartmouth.tri'
-    import urllib
+    from six.moves import urllib
     print('Downloading Dartmouth isochrone pre-computed triangulation (should happen only once...)')
     if os.path.exists(TRI_FILE):
         os.remove(TRI_FILE)
-    urllib.urlretrieve(url,TRI_FILE)
+    urllib.request.urlretrieve(url,TRI_FILE)
 
 if not os.path.exists(MASTERFILE):
     _download_h5()
@@ -111,9 +111,14 @@ class Dartmouth_Isochrone(Isochrone):
                 else:
                     raise
 
-        f = open(TRI_FILE,'rb')
-        tri = pickle.load(f)
-        f.close()
+        try:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f)
+        except:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f,encoding='latin-1')
+        finally:
+            f.close()
         
         Isochrone.__init__(self,df['M/Mo'],np.log10(df['age']*1e9),
                            df['feh'],df['M/Mo'],df['LogL/Lo'],

--- a/isochrones/padova.py
+++ b/isochrones/padova.py
@@ -19,19 +19,19 @@ TRI_FILE = '{}/padova.tri'.format(DATADIR)
 
 def _download_h5():
     url = 'http://zenodo.org/record/12800/files/padova.h5'
-    import urllib
+    from six.moves import urllib
     print('Downloading Padova stellar model data (should happen only once)...')
     if os.path.exists(MASTERFILE):
         os.remove(MASTERFILE)
-    urllib.urlretrieve(url,MASTERFILE)
+    urllib.request.urlretrieve(url,MASTERFILE)
 
 def _download_tri():
     url = 'http://zenodo.org/record/12800/files/padova.tri'
-    import urllib
+    from six.moves import urllib
     print('Downloading Padova isochrone pre-computed triangulation (should happen only once...)')
     if os.path.exists(TRI_FILE):
         os.remove(TRI_FILE)
-    urllib.urlretrieve(url,TRI_FILE)
+    urllib.request.urlretrieve(url,TRI_FILE)
 
 if not os.path.exists(MASTERFILE):
     _download_h5()
@@ -54,9 +54,14 @@ class Padova_Isochrone(Isochrone):
         for band in bands:
             mags[band] = df[band]
 
-        f = open(TRI_FILE,'rb')
-        tri = pickle.load(f)
-        f.close()
+        try:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f)
+        except:
+            f = open(TRI_FILE,'rb')
+            tri = pickle.load(f,encoding='latin-1')
+        finally:
+            f.close()
         
         Isochrone.__init__(self,df['M_ini'],df['age'],df['feh'],
                            df['M_act'],df['logL'],


### PR DESCRIPTION
First - thanks for the amazing library.

Second - I'm teaching an observational astronomy class this autumn and the students are going to be fitting CMDs that they create with your isochrones library. However, we're on enforced Python3 at the University and there's a few things in your library that I noticed don't work with Python 3. 

Check out the attached pull request for that. 

If it's possible, it would be *amazing* if the version accessible via pip acquired these changes before late October, when my students will start using the library.