### PR TITLE
Change cPickle to _pickle

### DIFF
--- a/isochrones/dartmouth/tri.py
+++ b/isochrones/dartmouth/tri.py
@@ -3,7 +3,7 @@
 import sys, os
 import pandas as pd
 import numpy as np
-import cPickle as pickle
+import _pickle as pickle
 from scipy.interpolate import LinearNDInterpolator as interpnd
 
 from ..config import ISOCHRONES

--- a/isochrones/dartmouth/tri.py
+++ b/isochrones/dartmouth/tri.py
@@ -3,7 +3,10 @@
 import sys, os
 import pandas as pd
 import numpy as np
-import _pickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from scipy.interpolate import LinearNDInterpolator as interpnd
 
 from ..config import ISOCHRONES


### PR DESCRIPTION
This is another Py3 update I came across. cPickle was changed to _pickle.