### PR TITLE
Check common columns with attribute

### DIFF
--- a/isochrones/grid.py
+++ b/isochrones/grid.py
@@ -104,7 +104,7 @@ class ModelGrid(object):
             logging.debug('loading {} band from {}'.format(b,s))
             if s not in grids:
                 grids[s] = self.get_hdf(s)
-            if 'MMo' not in df:
+            if self.common_columns[0] not in df:
                 df[list(self.common_columns)] = grids[s][list(self.common_columns)]
             col = grids[s][b]
             n_nan = np.isnan(col).sum()


### PR DESCRIPTION
Trying out examples in doc, I found that there's a redundant adding of common columns for MIST model because you check with 'MMo' whether common columns have been added, and it is not one of them for mist modelgrid:
('EEP',
 'log10_isochrone_age_yr',
 'initial_mass',
 'log_Teff',
 'log_g',
 'log_L',
 'Z_surf',
 'feh',
 'phase')

Also, I think scipy and numba is missing from requirements?