### PR TITLE
Make sure custom interpolation can handle nans.

### DIFF
--- a/isochrones/interp.py
+++ b/isochrones/interp.py
@@ -188,7 +188,8 @@ def interp_value(mass, age, feh, icol,
     TODO:  fix situation where there is exact match in age, feh, so we just
     interpolate along the track, not between...
     """
-
+    if np.isnan(mass) or np.isnan(age) or np.isnan(feh):
+        return np.nan
 
     Nage = len(ages)
     Nfeh = len(fehs)

--- a/isochrones/tests/tests.py
+++ b/isochrones/tests/tests.py
@@ -72,6 +72,10 @@ def _basic_ic_checks(ic):
     # Make sure no ZeroDivisionError for on-the-grid calls (Github issue #64)
     ic.isochrone(8.0, feh=0.)
 
+    # Make sure that passing nan returns nan (Github issue #65)
+    assert np.isnan(ic.radius(1.0, np.nan, 0.1))
+
+
 def _check_spec(ic):
     mod = StarModel(ic, Teff=(5700,100), logg=(4.5, 0.1), feh=(0.0, 0.2))
     assert np.isfinite(mod.lnlike([1.0, 9.6, 0.1, 200, 0.2]))


### PR DESCRIPTION
This avoids very undesirable behavior (i.e., needing to restart kernel).  Fixes #65.