### PR TITLE
fix pickling issue

### DIFF
--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -609,6 +609,12 @@ class FastIsochrone(Isochrone):
                      'minage','maxage','minfeh','maxfeh','minmass','maxmass']:
             _ = getattr(self, attr)
 
+    def __getstate__(self):
+        odict = self.__dict__.copy()
+        return odict
+
+    def __setstate__(self, odict):
+        self.__dict__ = odict
 
     @property
     def df(self):


### PR DESCRIPTION
Hi, 

The isochrone object (MIST_Isochrone) is not able to deal with pickling.
Here is an illustration.

$ cat /tmp/bb.py 
```
from isochrones.mist import MIST_Isochrone
import multiprocessing as mp


def func(x):
    return x([6],[7],[-1])

if __name__ == '__main__':
    pool=mp.Pool(16)
    iso=MIST_Isochrone()
    
    pool.map(func,[iso,iso])
```

$ python /tmp/bb.py
```
 multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/tmp/bb.py", line 6, in func
    return x([6],[7],[-1])
  File "/home/koposov/pyenv3/lib/python3.5/site-packages/isochrones/isochrone.py", line 283, in __call__
    mags = {band:1*self.mag[band](*args) for band in bands}
  File "/home/koposov/pyenv3/lib/python3.5/site-packages/isochrones/isochrone.py", line 283, in <dictcomp>
    mags = {band:1*self.mag[band](*args) for band in bands}
  File "/home/koposov/pyenv3/lib/python3.5/site-packages/isochrones/isochrone.py", line 237, in fn
    return self._mag[band](mass, age, feh) + dm + A
AttributeError: 'MIST_Isochrone' object has no attribute '_mag'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/bb.py", line 12, in <module>
    pool.map(func,[iso,iso])
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 260, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 608, in get
    raise self._value
AttributeError: 'MIST_Isochrone' object has no attribute '_mag'
```

The simple fix to the __setstate__ __getstate__ methods seems to fix the issue.