### PR TITLE
Adding name to logger

### DIFF
--- a/isochrones/cluster.py
+++ b/isochrones/cluster.py
@@ -1,5 +1,4 @@
 import re
-import logging
 
 import numpy as np
 import pandas as pd
@@ -13,6 +12,7 @@ from .starmodel import SingleStarModel, BinaryStarModel, TripleStarModel
 from .priors import PowerLawPrior, FlatLogPrior, FehPrior, FlatPrior, GaussianPrior
 from .utils import addmags, band_pairs
 from .cluster_utils import calc_lnlike_grid, integrate_over_eeps
+from .logger import getLogger
 
 
 def clusterfit(starfile, bands=None, props=None, models='mist', max_distance=10000,
@@ -53,7 +53,7 @@ class StarCatalog(object):
     Parameters
     ----------
     df : `pandas.DataFrame`
-        Table containing stellar measurements.  Names of uncertainty columns are 
+        Table containing stellar measurements.  Names of uncertainty columns are
         tagged with `_unc`.  If `bands` is not provided, then names of photometric
         bandpasses will be determined by looking for columns tagged with `_mag`.
 
@@ -462,7 +462,7 @@ class StarClusterModel(StarModel):
                     lnprob = np.array([chain[-1]])
                     chain = np.array([chain[:-1]])
             except:
-                logging.error('Error loading chains from {}'.format(filename))
+                getLogger().error('Error loading chains from {}'.format(filename))
                 raise
         else:
             chain = self.sampler.flatchain

--- a/isochrones/fit.py
+++ b/isochrones/fit.py
@@ -1,10 +1,10 @@
 import os, sys
 import pandas as pd
 import numpy as np
-import logging
 
 import emcee3
 from emcee3.backends import Backend, HDFBackend
+
 
 class Emcee3Model(emcee3.Model):
     def __init__(self, mod, *args, **kwargs):
@@ -29,7 +29,7 @@ class Emcee3PriorModel(emcee3.Model):
         return state
 
     def compute_log_likelihood(self, state):
-        state.log_likelihood = 0 
+        state.log_likelihood = 0
         return state
 
 def write_samples(mod, df, resultsdir='results'):
@@ -146,6 +146,6 @@ def fit_emcee3(mod, nwalkers=500, verbose=False, nsamples=5000, targetn=4,
 
     df = pd.DataFrame(samples, columns=mod.param_names)
     write_samples(mod, df, resultsdir=resultsdir)
-    
+
     return df
-    # return sampler    
+    # return sampler

--- a/isochrones/grid.py
+++ b/isochrones/grid.py
@@ -1,10 +1,10 @@
 import pandas as pd
 import os
-import logging
 import tarfile
 
 from .utils import download_file
 from .interp import DFInterpolator
+from .logger import getLogger
 
 
 class Grid(object):
@@ -82,7 +82,7 @@ class Grid(object):
         tarball = self.get_tarball_file(**kwargs)
         if not os.path.exists(tarball):
             url = self.get_tarball_url(**kwargs)
-            logging.info('Downloading {}...'.format(url))
+            getLogger().info('Downloading {}...'.format(url))
             download_file(url, tarball)
 
     def extract_tarball(self, **kwargs):
@@ -92,10 +92,10 @@ class Grid(object):
 
         try:
             with tarfile.open(tarball) as tar:
-                logging.info('Extracting {}...'.format(tarball))
+                getLogger().info('Extracting {}...'.format(tarball))
                 tar.extractall(self.datadir)
         except EOFError:
-            logging.error('{} corrupted; deleting and re-downloading.'.format(tarball))
+            getLogger().error('{} corrupted; deleting and re-downloading.'.format(tarball))
             os.remove(tarball)
             self.extract_tarball(**kwargs)
 
@@ -113,7 +113,7 @@ class Grid(object):
         h5file = self.hdf_filename
         path = 'orig' if orig else 'df'
         df.to_hdf(h5file, path)
-        logging.info('{} written to {}.'.format(path, h5file))
+        getLogger().info('{} written to {}.'.format(path, h5file))
         return df
 
     @property

--- a/isochrones/interp.py
+++ b/isochrones/interp.py
@@ -1,6 +1,5 @@
 import os
 import itertools
-import logging
 
 import numba as nb
 from math import sqrt

--- a/isochrones/isochrone.py
+++ b/isochrones/isochrone.py
@@ -2,14 +2,15 @@ from .config import on_rtd
 
 import os, re, sys
 import warnings
-import logging
 import itertools
 import pickle
+
+from .logger import getLogger
 
 try:
     import holoviews as hv
 except ImportError:
-    logging.warning('Holoviews not imported. Some visualizations will not be available.')
+    getLogger().warning('Holoviews not imported. Some visualizations will not be available.')
     pass
 
 if not on_rtd:
@@ -66,7 +67,7 @@ def get_ichrone(models, bands=None, default=False, tracks=False, basic=False, **
                 ichrone = MISTBasic_Isochrone(bands=bands, **kwargs)
             else:
                 from isochrones.mist import MIST_Isochrone
-                ichrone = MIST_Isochrone(bands=bands, **kwargs)           
+                ichrone = MIST_Isochrone(bands=bands, **kwargs)
     else:
         raise ValueError('Unknown stellar models: {}'.format(models))
     return ichrone

--- a/isochrones/logger.py
+++ b/isochrones/logger.py
@@ -1,0 +1,27 @@
+__all__ = ["getLogger", "initLogging"]
+
+import sys
+import logging
+
+
+def getLogger():
+    return logging.getLogger("isochrones")
+
+
+def initLogging(filename, logger):
+    if logger is None:
+        logger = getLogger()
+    else:  # wish there was a logger.close()
+        for handler in logger.handlers[:]:  # make a copy of the list
+            logger.removeHandler(handler)
+
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter(fmt='%(asctime)s: %(message)s')
+
+    fh = logging.FileHandler(filename)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    logger.addHandler(sh)
+    return logger

--- a/isochrones/mist/models.py
+++ b/isochrones/mist/models.py
@@ -2,7 +2,6 @@ import os
 import re
 import glob
 import itertools
-import logging
 from functools import partial
 
 import numpy as np
@@ -18,7 +17,7 @@ from .eep import max_eep
 from ..interp import DFInterpolator, searchsorted
 from ..utils import polyval
 from .eep import max_eep
-
+from ..logger import getLogger
 
 class MISTModelGrid(StellarModelGrid):
     name = 'mist'
@@ -290,7 +289,7 @@ class MISTEvolutionTrackGrid(MISTModelGrid):
         if os.path.exists(hdf_filename):
             df_interp = pd.read_hdf(hdf_filename, 'df')
         else:
-            logging.info('Interpolating incomplete tracks for feh = {}'.format(feh))
+            getLogger().info('Interpolating incomplete tracks for feh = {}'.format(feh))
             df = self.df_all_feh(feh)
             df_interp = df.copy()
             df_interp['interpolated'] = False
@@ -327,7 +326,7 @@ class MISTEvolutionTrackGrid(MISTModelGrid):
                         if ihi > len(masses):
                             raise ValueError('Did not find mhi for ({}, {})'.format(m, feh))
 
-                    logging.info('{}: {} (expected {}).  Interpolating between {} and {}'.format(m, n_eep, eep_max, mlo, mhi))
+                    getLogger().info('{}: {} (expected {}).  Interpolating between {} and {}'.format(m, n_eep, eep_max, mlo, mhi))
                     new_eeps = np.arange(n_eep + 1, eep_max + 1)
                     new_index = pd.MultiIndex.from_product([[feh], [m], new_eeps])
                     new_data = pd.DataFrame(index=new_index, columns=df_interp.columns, dtype=float)
@@ -499,7 +498,7 @@ class MISTEvolutionTrackGrid(MISTModelGrid):
                 if age > eep_fn_pars[-2]:
                     return polyval(self.eep_interps[-1]([feh, mass], 'all'), age)  # assume you're in last bit
                 else:
-                    logging.warning('EEP conversion failed for mass={}, age={}, feh={} (approx eep = {}).  Returning nan.'.format(mass, age, feh, eep))
+                    getLogger().warning('EEP conversion failed for mass={}, age={}, feh={} (approx eep = {}).  Returning nan.'.format(mass, age, feh, eep))
                     return np.nan
 
     def view_eep_fit(self, mass, feh, plot_fit=True, order=5, p0=None, plot_p0=False):

--- a/isochrones/observation.py
+++ b/isochrones/observation.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division
 import os, re, sys
-import logging
 
 from .config import on_rtd
+from .logger import getLogger
 
 if not on_rtd:
     import numpy as np
@@ -195,7 +195,7 @@ class Node(object):
                 ind = i
 
         if ind is None:
-            logging.warning('No child labeled {}.'.format(label))
+            getLogger().warning('No child labeled {}.'.format(label))
             return
         self.children.pop(ind)
         self._clear_all_leaves()
@@ -486,7 +486,7 @@ class ObsNode(Node):
         lnl = -0.5*(mag - mod)**2 / dmag**2 + LOG_ONE_OVER_ROOT_2PI + np.log(dmag)
 
 
-        # logging.debug('{} {}: mag={}, mod={}, lnlike={}'.format(self.instrument,
+        # getLogger().debug('{} {}: mag={}, mod={}, lnlike={}'.format(self.instrument,
         #                                                         self.band,
         #                                                         mag,mod,lnl))
         return lnl

--- a/isochrones/priors.py
+++ b/isochrones/priors.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-import logging
 
 import numpy as np
 import pandas as pd
@@ -12,6 +11,8 @@ import matplotlib.pyplot as plt
 import numba as nb
 from math import log, log10
 
+
+from .logger import getLogger
 
 _norm_pdf_C = np.sqrt(2*np.pi)
 ONE_OVER_ROOT_2PI = 1./_norm_pdf_C
@@ -79,15 +80,16 @@ class Prior(object):
             rng = None
         hn, _ = np.histogram(x, range=rng)
         h, b = np.histogram(x, density=True, range=rng)
-        logging.debug('bins: {}'.format(b))
-        logging.debug('raw: {}'.format(hn))
+        logger = getLogger()
+        logger.debug('bins: {}'.format(b))
+        logger.debug('raw: {}'.format(hn))
         pdf = np.array([quad(self.pdf, lo, hi)[0]/(hi-lo) for lo, hi in zip(b[:-1], b[1:])])
         sigma = 1./np.sqrt(hn)
         resid = np.absolute(pdf - h) / pdf
-        logging.debug('pdf: {}'.format(pdf))
-        logging.debug('hist: {}'.format(h))
-        logging.debug('sigma: {}'.format(sigma))
-        logging.debug('{}'.format(resid/sigma))
+        logger.debug('pdf: {}'.format(pdf))
+        logger.debug('hist: {}'.format(h))
+        logger.debug('sigma: {}'.format(sigma))
+        logger.debug('{}'.format(resid/sigma))
 
         c = (b[:-1] + b[1:])/2
         if plot:

--- a/isochrones/starfit.py
+++ b/isochrones/starfit.py
@@ -13,8 +13,8 @@ from .starmodel import StarModel, BasicStarModel
 from .isochrone import get_ichrone
 
 def initLogging(filename, logger):
-    if logger == None:
-        logger = logging.getLogger()
+    if logger is None:
+        logger = logging.getLogger("isochrones")
     else:  # wish there was a logger.close()
         for handler in logger.handlers[:]:  # make a copy of the list
             logger.removeHandler(handler)

--- a/isochrones/starfit.py
+++ b/isochrones/starfit.py
@@ -1,5 +1,4 @@
 import os, os.path, re, sys
-import logging
 import time
 
 from .config import on_rtd
@@ -12,23 +11,7 @@ from configobj import ConfigObj
 from .starmodel import StarModel, BasicStarModel
 from .isochrone import get_ichrone
 
-def initLogging(filename, logger):
-    if logger is None:
-        logger = logging.getLogger("isochrones")
-    else:  # wish there was a logger.close()
-        for handler in logger.handlers[:]:  # make a copy of the list
-            logger.removeHandler(handler)
-
-    logger.setLevel(logging.INFO)
-    formatter = logging.Formatter(fmt='%(asctime)s: %(message)s')
-
-    fh = logging.FileHandler(filename)
-    fh.setFormatter(formatter)
-    logger.addHandler(fh)
-
-    sh = logging.StreamHandler(sys.stdout)
-    logger.addHandler(sh)
-    return logger
+from .logger import initLogging
 
 
 def starfit(folder, multiplicities=['single'], models='mist',

--- a/isochrones/starmodel.py
+++ b/isochrones/starmodel.py
@@ -2,10 +2,13 @@ from __future__ import print_function, division
 
 import os, os.path, sys, re, glob
 import itertools
-from copy impo
+from copy import deepcopy
+import json
 
 from .config import on_rtd
+
 from .logger import getLogger
+logger = getLogger()
 
 if not on_rtd:
     import numpy as np
@@ -20,7 +23,7 @@ if not on_rtd:
     try:
         import pymultinest
     except ImportError:
-        getLogger().warning('PyMultiNest not imported.  MultiNest fits will not work.')
+        logger.warning('PyMultiNest not imported.  MultiNest fits will not work.')
 
     import configobj
     from astropy.coordinates import SkyCoord
@@ -41,7 +44,7 @@ from .likelihood import star_lnlike, gauss_lnprob
 try:
     from .fit import fit_emcee3
 except ImportError:
-    getLogger().warning('Emcee3 not imported; be advised.')
+    logger.warning('Emcee3 not imported; be advised.')
 
 def _parse_config_value(v):
     try:
@@ -286,7 +289,7 @@ class StarModel(object):
         if not isinstance(ic, ModelGridInterpolator):
             ic = get_ichrone(ic, bands)
 
-        getLogger().debug('Initializing StarModel from {}'.format(ini_file))
+        logger.debug('Initializing StarModel from {}'.format(ini_file))
 
         c = configobj.ConfigObj(ini_file)
 
@@ -392,7 +395,7 @@ class StarModel(object):
         if 'obsfile' in c:
             obs = c['obsfile']
 
-        getLogger().debug('Obs is {}'.format(obs))
+        logger.debug('Obs is {}'.format(obs))
 
         name = kwargs.pop('name', os.path.basename(folder))
         new = cls(ic, obs=obs, **kwargs, name=name)
@@ -452,18 +455,18 @@ class StarModel(object):
 
         Creates self.obs
         """
-        getLogger().debug('Building ObservationTree...')
+        logger.debug('Building ObservationTree...')
         tree = ObservationTree()
         for k,v in kwargs.items():
             if k in self.ic.bands:
                 if np.size(v) != 2:
-                    getLogger().warning('{}={} ignored (no uncertainty).'.format(k,v))
+                    logger.warning('{}={} ignored (no uncertainty).'.format(k,v))
                     # continue
                     v = [v, np.nan]
                 o = Observation('', k, 99) #bogus resolution=99
                 s = Source(v[0], v[1])
                 o.add_source(s)
-                getLogger().debug('Adding {} ({})'.format(s,o))
+                logger.debug('Adding {} ({})'.format(s,o))
                 tree.add_observation(o)
 
 
@@ -536,7 +539,7 @@ class StarModel(object):
                         return -np.inf
                     lnp += self._priors[prop].lnpdf(val)
                     if not np.isfinite(lnp):
-                        getLogger().debug('lnp=-inf for {}={} (system {})'.format(prop, val, s))
+                        logger.debug('lnp=-inf for {}={} (system {})'.format(prop, val, s))
                         return -np.inf
 
                 # Note: this all is just assuming proper order for multiple stars.
@@ -572,7 +575,7 @@ class StarModel(object):
 
                 #     lnp += np.log(self.prior('q', q))
                 #     if not np.isfinite(lnp):
-                #         getLogger().debug('lnp=-inf for q={} (system {})'.format(q, s))
+                #         logger.debug('lnp=-inf for q={} (system {})'.format(q, s))
                 #         return -np.inf
 
                 i += N[s] + 4
@@ -730,7 +733,7 @@ class StarModel(object):
 
         basename = self.mnest_basename
         if verbose:
-            getLogger().info('MultiNest basename: {}'.format(basename))
+            logger.info('MultiNest basename: {}'.format(basename))
 
         folder = os.path.abspath(os.path.dirname(basename))
         if rank == 0 or force_no_MPI:
@@ -904,7 +907,7 @@ class StarModel(object):
         npars = self.n_params
 
         if p0 is None:
-            getLogger().debug('Generating initial p0 for {} walkers...'.format(nwalkers))
+            logger.debug('Generating initial p0 for {} walkers...'.format(nwalkers))
             p0 = self.emcee_p0(nwalkers)
             if initial_burn:
                 sampler = emcee.EnsembleSampler(nwalkers, npars, self.lnpost,
@@ -916,9 +919,9 @@ class StarModel(object):
                 i, j = np.unravel_index(sampler.lnprobability.argmax(),
                                         sampler.shape)
                 p0_best = sampler.chain[i, j, :]
-                getLogger().debug("After initial burn, p0={}".format(p0_best))
+                logger.debug("After initial burn, p0={}".format(p0_best))
                 p0 = p0_best * (1 + rand.normal(size=p0.shape) * 0.001)
-                getLogger().debug(p0)
+                logger.debug(p0)
         else:
             p0 = np.array(p0)
             p0 = rand.normal(size=(nwalkers, npars))*0.01 + p0.T[None, :]
@@ -954,7 +957,7 @@ class StarModel(object):
                     lnprob = np.array([chain[-1]])
                     chain = np.array([chain[:-1]])
             except:
-                getLogger().error('Error loading chains from {}'.format(filename))
+                logger.error('Error loading chains from {}'.format(filename))
                 raise
         else:
             chain = self.sampler.flatchain
@@ -1057,7 +1060,7 @@ class StarModel(object):
         try:
             fig = corner.corner(df[params], labels=params, priors=priors, **kwargs)
         except:
-            getLogger().warning("Use Tim's version of corner to plot priors.")
+            logger.warning("Use Tim's version of corner to plot priors.")
             fig = corner.corner(df[params], labels=params, **kwargs)
         fig.suptitle(self.name, fontsize=22)
         return fig
@@ -1366,7 +1369,7 @@ class BasicStarModel(StarModel):
                 if not (np.isnan(val) or np.isnan(unc)):
                     self.kwargs[k] = v
             except TypeError:
-                getLogger().warning('kwarg {}={} ignored!'.format(k, v))
+                logger.warning('kwarg {}={} ignored!'.format(k, v))
 
         self._bands = None
         self._spec_props = None
@@ -1570,7 +1573,7 @@ class BasicStarModel(StarModel):
         try:
             df = pd.read_csv(filename, names=self.param_names + ('lnprob',), delim_whitespace=True)
         except OSError:
-            getLogger().error('Error loading chains from {}'.format(filename))
+            logger.error('Error loading chains from {}'.format(filename))
             raise
 
         self._samples = df

--- a/isochrones/starmodel.py
+++ b/isochrones/starmodel.py
@@ -2,11 +2,10 @@ from __future__ import print_function, division
 
 import os, os.path, sys, re, glob
 import itertools
-from copy import deepcopy
-import logging
-import json
+from copy impo
 
 from .config import on_rtd
+from .logger import getLogger
 
 if not on_rtd:
     import numpy as np
@@ -21,7 +20,7 @@ if not on_rtd:
     try:
         import pymultinest
     except ImportError:
-        logging.warning('PyMultiNest not imported.  MultiNest fits will not work.')
+        getLogger().warning('PyMultiNest not imported.  MultiNest fits will not work.')
 
     import configobj
     from astropy.coordinates import SkyCoord
@@ -42,7 +41,7 @@ from .likelihood import star_lnlike, gauss_lnprob
 try:
     from .fit import fit_emcee3
 except ImportError:
-    logging.warning('Emcee3 not imported; be advised.')
+    getLogger().warning('Emcee3 not imported; be advised.')
 
 def _parse_config_value(v):
     try:
@@ -287,7 +286,7 @@ class StarModel(object):
         if not isinstance(ic, ModelGridInterpolator):
             ic = get_ichrone(ic, bands)
 
-        logging.debug('Initializing StarModel from {}'.format(ini_file))
+        getLogger().debug('Initializing StarModel from {}'.format(ini_file))
 
         c = configobj.ConfigObj(ini_file)
 
@@ -393,7 +392,7 @@ class StarModel(object):
         if 'obsfile' in c:
             obs = c['obsfile']
 
-        logging.debug('Obs is {}'.format(obs))
+        getLogger().debug('Obs is {}'.format(obs))
 
         name = kwargs.pop('name', os.path.basename(folder))
         new = cls(ic, obs=obs, **kwargs, name=name)
@@ -453,18 +452,18 @@ class StarModel(object):
 
         Creates self.obs
         """
-        logging.debug('Building ObservationTree...')
+        getLogger().debug('Building ObservationTree...')
         tree = ObservationTree()
         for k,v in kwargs.items():
             if k in self.ic.bands:
                 if np.size(v) != 2:
-                    logging.warning('{}={} ignored (no uncertainty).'.format(k,v))
+                    getLogger().warning('{}={} ignored (no uncertainty).'.format(k,v))
                     # continue
                     v = [v, np.nan]
                 o = Observation('', k, 99) #bogus resolution=99
                 s = Source(v[0], v[1])
                 o.add_source(s)
-                logging.debug('Adding {} ({})'.format(s,o))
+                getLogger().debug('Adding {} ({})'.format(s,o))
                 tree.add_observation(o)
 
 
@@ -537,7 +536,7 @@ class StarModel(object):
                         return -np.inf
                     lnp += self._priors[prop].lnpdf(val)
                     if not np.isfinite(lnp):
-                        logging.debug('lnp=-inf for {}={} (system {})'.format(prop, val, s))
+                        getLogger().debug('lnp=-inf for {}={} (system {})'.format(prop, val, s))
                         return -np.inf
 
                 # Note: this all is just assuming proper order for multiple stars.
@@ -573,7 +572,7 @@ class StarModel(object):
 
                 #     lnp += np.log(self.prior('q', q))
                 #     if not np.isfinite(lnp):
-                #         logging.debug('lnp=-inf for q={} (system {})'.format(q, s))
+                #         getLogger().debug('lnp=-inf for q={} (system {})'.format(q, s))
                 #         return -np.inf
 
                 i += N[s] + 4
@@ -731,7 +730,7 @@ class StarModel(object):
 
         basename = self.mnest_basename
         if verbose:
-            logging.info('MultiNest basename: {}'.format(basename))
+            getLogger().info('MultiNest basename: {}'.format(basename))
 
         folder = os.path.abspath(os.path.dirname(basename))
         if rank == 0 or force_no_MPI:
@@ -905,7 +904,7 @@ class StarModel(object):
         npars = self.n_params
 
         if p0 is None:
-            logging.debug('Generating initial p0 for {} walkers...'.format(nwalkers))
+            getLogger().debug('Generating initial p0 for {} walkers...'.format(nwalkers))
             p0 = self.emcee_p0(nwalkers)
             if initial_burn:
                 sampler = emcee.EnsembleSampler(nwalkers, npars, self.lnpost,
@@ -917,9 +916,9 @@ class StarModel(object):
                 i, j = np.unravel_index(sampler.lnprobability.argmax(),
                                         sampler.shape)
                 p0_best = sampler.chain[i, j, :]
-                logging.debug("After initial burn, p0={}".format(p0_best))
+                getLogger().debug("After initial burn, p0={}".format(p0_best))
                 p0 = p0_best * (1 + rand.normal(size=p0.shape) * 0.001)
-                logging.debug(p0)
+                getLogger().debug(p0)
         else:
             p0 = np.array(p0)
             p0 = rand.normal(size=(nwalkers, npars))*0.01 + p0.T[None, :]
@@ -955,7 +954,7 @@ class StarModel(object):
                     lnprob = np.array([chain[-1]])
                     chain = np.array([chain[:-1]])
             except:
-                logging.error('Error loading chains from {}'.format(filename))
+                getLogger().error('Error loading chains from {}'.format(filename))
                 raise
         else:
             chain = self.sampler.flatchain
@@ -1058,7 +1057,7 @@ class StarModel(object):
         try:
             fig = corner.corner(df[params], labels=params, priors=priors, **kwargs)
         except:
-            logging.warning("Use Tim's version of corner to plot priors.")
+            getLogger().warning("Use Tim's version of corner to plot priors.")
             fig = corner.corner(df[params], labels=params, **kwargs)
         fig.suptitle(self.name, fontsize=22)
         return fig
@@ -1367,7 +1366,7 @@ class BasicStarModel(StarModel):
                 if not (np.isnan(val) or np.isnan(unc)):
                     self.kwargs[k] = v
             except TypeError:
-                logging.warning('kwarg {}={} ignored!'.format(k, v))
+                getLogger().warning('kwarg {}={} ignored!'.format(k, v))
 
         self._bands = None
         self._spec_props = None
@@ -1571,7 +1570,7 @@ class BasicStarModel(StarModel):
         try:
             df = pd.read_csv(filename, names=self.param_names + ('lnprob',), delim_whitespace=True)
         except OSError:
-            logging.error('Error loading chains from {}'.format(filename))
+            getLogger().error('Error loading chains from {}'.format(filename))
             raise
 
         self._samples = df

--- a/isochrones/summary.py
+++ b/isochrones/summary.py
@@ -1,7 +1,6 @@
 import os, sys, re
 import numpy as np
 import pandas as pd
-import logging
 from multiprocessing import Pool
 
 from .starmodel import StarModel, BasicStarModel

--- a/isochrones/tests/test_fits.py
+++ b/isochrones/tests/test_fits.py
@@ -2,20 +2,19 @@ import os, glob
 import numpy as np
 import tempfile
 import tables as tb
-import logging
 
 from pandas.util.testing import assert_frame_equal
 
 from isochrones.mist import MIST_Isochrone
 from isochrones import StarModel
 from isochrones.starfit import starfit
+from isochrones.logger import getLogger
 
 mnest = True
 try:
     import pymultinest
 except:
-    import logging
-    logging.warning('No PyMultiNest; fits will use emcee')
+    getLogger().warning('No PyMultiNest; fits will use emcee')
     mnest = False
 
 chainsdir = tempfile.gettempdir()

--- a/isochrones/tests/test_interp.py
+++ b/isochrones/tests/test_interp.py
@@ -1,12 +1,11 @@
 import itertools
-import logging
 
 import numpy as np
 import pandas as pd
 from scipy.interpolate import RegularGridInterpolator
 
 from isochrones.interp import DFInterpolator
-
+from isochrones.logger import getLogger
 
 def test_interp():
     xx, yy, zz = [np.arange(10 + np.log10(n))*n for n in [1, 10, 100]]
@@ -32,7 +31,7 @@ def test_interp():
     try:
         assert np.isclose(df_interp(pars, ['val']), interp(pars)[0], atol=1e-11)
     except AssertionError:
-        logging.debug('mine: {}, scipy: {}'.format(df_interp(pars, ['val']), interp(pars)[0]))
+        getLogger().debug('mine: {}, scipy: {}'.format(df_interp(pars, ['val']), interp(pars)[0]))
         raise
 
     pts = np.random.random(size=(10, 3)) * 9

--- a/isochrones/tests/tests.py
+++ b/isochrones/tests/tests.py
@@ -1,7 +1,6 @@
 
 import tempfile
 import os, shutil, glob
-import logging
 
 import numpy as np
 from numba import TypingError
@@ -54,7 +53,7 @@ def _check_closest_eep(ic, n=3000, resid_tol=0.02):
     masses = np.random.random(n) * 2.5 + 0.1
     fehs = np.random.random(n) * (ic.maxfeh - ic.minfeh) + ic.minfeh
     ages = np.random.random(n) * (10.0 - ic.minage) + ic.minage
-    eeps = [ic.get_eep(m, a, f, return_nan=True, 
+    eeps = [ic.get_eep(m, a, f, return_nan=True,
                        resid_tol=resid_tol, accurate=True) for m, a, f in zip(masses, ages, fehs)]
     for e, a, f, m in zip(eeps, ages, fehs, masses):
         if not np.isnan(e):
@@ -68,7 +67,7 @@ def _check_closest_eep(ic, n=3000, resid_tol=0.02):
     # make sure the minmass edge case works.
     for feh in ic.fehs[1: -1]:  # first and last feh of mist doesn't work.
         try:
-            assert np.isfinite(ic.get_eep(ic.minmass+0.01, 9.0, feh, return_nan=True, 
+            assert np.isfinite(ic.get_eep(ic.minmass+0.01, 9.0, feh, return_nan=True,
                                           resid_tol=resid_tol, accurate=True))
         except AssertionError:
             ic.get_eep(ic.minmass+0.01, 9.0, feh, debug=True)

--- a/isochrones/utils.py
+++ b/isochrones/utils.py
@@ -2,12 +2,12 @@ from __future__ import print_function, division
 
 import requests
 import os
-import logging
 
 import numpy as np
 import numba as nb
 from math import log10
 
+from .logger import getLogger
 
 def band_pairs(bands):
     return [(bands[i], bands[-1]) for i in range(len(bands)-1)]
@@ -25,7 +25,7 @@ def download_file(url, path=None, clobber=False):
         local_filename = path
 
     if os.path.exists(local_filename) and not clobber:
-        logging.info('{} exists; not downloading.'.format(local_filename))
+        getLogger().info('{} exists; not downloading.'.format(local_filename))
         return local_filename
 
     # NOTE the stream=True parameter
@@ -76,12 +76,12 @@ def distance(pos0, pos1):
     """distance between two positions defined by (separation, PA)
     """
     r0, pa0 = pos0
-    #logging.debug('r0={}, pa0={} (from {})'.format(r0, pa0, self))
+    #getLogger().debug('r0={}, pa0={} (from {})'.format(r0, pa0, self))
     ra0 = r0*np.sin(pa0*np.pi/180)
     dec0 = r0*np.cos(pa0*np.pi/180)
 
     r1, pa1 = pos1
-    #logging.debug('r1={}, pa1={} (from {})'.format(r0, pa0, other))
+    #getLogger().debug('r1={}, pa1={} (from {})'.format(r0, pa0, other))
     ra1 = r1*np.sin(pa1*np.pi/180)
     dec1 = r1*np.cos(pa1*np.pi/180)
 


### PR DESCRIPTION
Currently isochrones hijacks the root logger and sets the level to `INFO` which isn't always what you want. This changes everywhere where `logging` was used before to use a named logger owned by `isochrones`.