### PR TITLE
fix the Chabrier prior

### DIFF
--- a/isochrones/priors.py
+++ b/isochrones/priors.py
@@ -515,5 +515,5 @@ class ChabrierPrior(BrokenPrior):
     def __init__(self, **kwargs):
         bounds = kwargs.pop("bounds", (0.1, 100.0))
         super().__init__(
-            [LogNormalPrior(0.079, 0.69), PowerLawPrior(-2.35, (1.0, 100.0))], [1.0], bounds=bounds, **kwargs
-        )
+            [LogNormalPrior(0.079, 0.69 * np.log(10)), PowerLawPrior(-2.35, (1.0, 100.0))], [1.0], bounds=bounds, **kwargs
+        )  # from Chabrier 2003, Eqn 17


### PR DESCRIPTION
Hi, 

The Chabrier prior is incorrect. there is a missing log(10) factor there.
Here is the illustration (the chabrier 2003 imf is defined such that Mean of log10(mass) is log10(0.079) and stddev of log10(mass) is 0.69)


Here is what you currently use for Chabrier:
```
In [18]: 10**np.log10(isochrones.priors.LogNormalPrior(np.log(0.079),.69).sample(100000)).mean()                                                
Out[18]: 0.07869121411187371

In [19]: 10**np.log10(isochrones.priors.LogNormalPrior(np.log(0.079),.69).sample(100000)).mean()                                                
Out[19]: 0.07915577207985923

In [20]: np.log10(isochrones.priors.LogNormalPrior(np.log(0.079),.69).sample(100000)).std()                                                     
Out[20]: 0.29955646294079435
```
The mean is correct but not stddev

Here is a correct form 
```

In [21]: np.log10(isochrones.priors.LogNormalPrior(np.log(0.079),.69*np.log(10)).sample(100000)).std()                                          
Out[21]: 0.6891607889864645

```

I attach the bug fix. 
(and thanks for the nice software!)
     Sergey