### PR TITLE
fix forgotten log() in Chabrier

### DIFF
--- a/isochrones/priors.py
+++ b/isochrones/priors.py
@@ -515,5 +515,5 @@ class ChabrierPrior(BrokenPrior):
     def __init__(self, **kwargs):
         bounds = kwargs.pop("bounds", (0.1, 100.0))
         super().__init__(
-            [LogNormalPrior(0.079, 0.69 * np.log(10)), PowerLawPrior(-2.35, (1.0, 100.0))], [1.0], bounds=bounds, **kwargs
+            [LogNormalPrior(np.log(0.079), 0.69 * np.log(10)), PowerLawPrior(-2.35, (1.0, 100.0))], [1.0], bounds=bounds, **kwargs
         )  # from Chabrier 2003, Eqn 17


### PR DESCRIPTION
In the issue #123 I correctly listed that the mean of the LogNormal 0.079 needs to be logged, but I haven't actually made that change to the code.
I apply that fix now. Sorry for buggy first commit.