### PR TITLE
Error in Regex

### DIFF
--- a/isochrones/starmodel.py
+++ b/isochrones/starmodel.py
@@ -219,7 +219,7 @@ class StarModel(object):
     def _parse_band(cls, kw):
         """Returns photometric band from inifile keyword
         """
-        m = re.search(r"([a-zA-Z0-9]+)(_\d+)?", kw)
+        m = re.search(r"[a-zA-Z0-9_]+", kw)
         if m:
             if m.group(1) in cls._not_a_band:
                 return None


### PR DESCRIPTION
The Regex expression currently in the repository is not reading certain magnitude bands correctly. For instance, it read "GALEX_NUV" as "GALEX," causing an error. This pull request should fix that.