### PR TITLE
Allow import of `isochrones` on readthedocs

### DIFF
--- a/isochrones/interp.py
+++ b/isochrones/interp.py
@@ -629,7 +629,7 @@ class DFInterpolator(object):
             return find_closest3(val, lo, hi, v1, v2, self.grid, icol, *self.index_columns, debug=debug)
 
     def __call__(self, p, cols="all"):
-        if cols is "all":
+        if cols == "all":
             icols = np.arange(self.n_columns)
         else:
             icols = np.array([self.column_index[col] for col in cols])

--- a/isochrones/observation.py
+++ b/isochrones/observation.py
@@ -22,6 +22,8 @@ if not on_rtd:
         imap = map
         izip = zip
         xrange = range
+
+    LOG_ONE_OVER_ROOT_2PI = np.log(1.0 / np.sqrt(2 * np.pi))
 else:
 
     class Traversal(object):
@@ -33,8 +35,6 @@ else:
 
 from .isochrone import get_ichrone
 from .utils import addmags, distance, fast_addmags
-
-LOG_ONE_OVER_ROOT_2PI = np.log(1.0 / np.sqrt(2 * np.pi))
 
 
 class NodeTraversal(Traversal):


### PR DESCRIPTION
Super small PR! I've moved the definition of `LOG_ONE_OVER_ROOT_2PI` to prevent a crash during import whilst on readthedocs - this will fix #176.

(I also changed a "is" to "==" to prevent warnings in the latest python version)