### PR TITLE
Add kind='stable' kwarg to argsort to make test_ini pass with NumPy > 1.24

### DIFF
--- a/isochrones/observation.py
+++ b/isochrones/observation.py
@@ -1257,7 +1257,7 @@ class ObservationTree(Node):
             except AttributeError:
                 pass
 
-        inds = np.argsort(ds)
+        inds = np.argsort(ds, kind='stable')
         ds = [ds[i] for i in inds]
         nodes = [nodes[i] for i in inds]
 


### PR DESCRIPTION
In a bid to get isochrones up to date, I've been running the tests with pytest using e.g.

```
$ python3 -m pytest isochrones/tests/
```

In the Python 3.9 environment I'm using with NumPy 1.26.4, this gives a single failure in `isochrones/tests/test_ini.py`:
```
FAILED isochrones/tests/test_ini.py::test_ini - ValueError: not enough values to unpack (expected 4, got 3)
```
With a bit of help from Claude Sonnet 4.6 (Low effort), I narrowed this down to a change in NumPy's default sort in v1.25 that made it unstable, though the stable of the earlier implementation was probably never guaranteed. I can't find crystal clear documentation about this. The changelog only mentions performance increases in [`numpy.sort`](https://numpy.org/doc/stable/release/1.25.0-notes.html#faster-np-sort-on-avx-512-enabled-processors) and [`.argsort`](https://numpy.org/doc/stable/release/1.25.0-notes.html#faster-np-argsort-on-avx-512-enabled-processors) on AVX-512 but there are various issues and PRs sprinkled around in response (e.g. https://github.com/pandas-dev/pandas/pull/53548).

The test is fixed by adding the `kind='stable'` keyword to the relevant argsort, as proposed in this PR.

Note, however, that I don't know the code well enough to know why this matters and whether this is a long-term solution or just a workaround. For reference, my MWE to iterate on the issue was
```py
from isochrones.mist import MIST_Isochrone
from isochrones import StarModel

ic = MIST_Isochrone()

m = StarModel.from_ini(
    ic,
    folder='isochrones/tests/star2',
    index=0,
)

pars = [1.0, 0.5, 9.4, 0.0, 100, 0.2]
eep_pars = m.convert_pars_to_eep(pars)
```

With this in place I'm more confident about porting the Travis CI scripts to GitHub Actions.