### PR TITLE
Update URLs to new MIST server

### DIFF
--- a/isochrones/bc.py
+++ b/isochrones/bc.py
@@ -90,7 +90,7 @@ class BolometricCorrectionGrid(Grid):
         return os.path.join(self.datadir, "{}.h5".format(phot))
 
     def get_tarball_url(self, phot):
-        url = "http://waps.cfa.harvard.edu/MIST/BC_tables/{}.txz".format(phot)
+        url = "https://mist.science/BC_tables/v1/{}.txz".format(phot)
         return url
 
     def get_tarball_file(self, phot):

--- a/isochrones/mist/models.py
+++ b/isochrones/mist/models.py
@@ -116,10 +116,10 @@ class MISTIsochroneGrid(MISTModelGrid):
     def get_tarball_url(self, **kwargs):
         """
         e.g.
-        http://waps.cfa.harvard.edu/MIST/data/tarballs_v1.2/MIST_v1.2_vvcrit0.4_full_isos.txz
+        https://mist.science/data/tarballs_v1.2/MIST_v1.2_vvcrit0.4_full_isos.txz
         """
         return (
-            "http://waps.cfa.harvard.edu/MIST/data/tarballs"
+            "https://mist.science/data/tarballs"
             + "_v{version}/MIST_v{version}_vvcrit{vvcrit}_{kind}.txz".format(**self.kwargs)
         )
 
@@ -240,7 +240,7 @@ class MISTEvolutionTrackGrid(MISTModelGrid):
     def get_tarball_url(self, feh):
         basename = self.get_file_basename(feh)
         version = self.kwargs["version"]
-        return "http://waps.cfa.harvard.edu/MIST/data/tarballs_v{version}/{basename}.txz".format(
+        return "https://mist.science/data/tarballs_v{version}/{basename}.txz".format(
             version=version, basename=basename
         )
         return os.path.join(self.datadir, "{}.txz".format(basename))

--- a/isochrones/utils.py
+++ b/isochrones/utils.py
@@ -32,6 +32,7 @@ def download_file(url, path=None, clobber=False):
 
     # NOTE the stream=True parameter
     r = requests.get(url, stream=True)
+    r.raise_for_status()
     with open(local_filename, "wb") as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks


### PR DESCRIPTION
While I've been working on porting the Travis CI to GitHub actions, I've just been struck by the old CFA URLs returning 404. This PR updates the URLs to the new locations on the MIST locations. This boils down to:

1. `http://waps.cfa.harvard.edu/MIST/data` → `https://mist.science/data`
2. `http://waps.cfa.harvard.edu/MIST/BC_tables` → `https://mist.science/BC_tables/v1`

Note that the BC tables now have a version field in the URL, which might need handling in the code at some point. It seems to correspond to the "major" part of the version for the isochrones and tracks. I.e. now that v2.5 isochrones and tracks are available, I think we'd have to use v2 BC tables. But I'm going to call that a problem for later when someone actually tries to use the v2.5 tables.

I also added a `requests.Response.raise_for_status` call to `utils.download_file` to make this easier to debug. At the moment, if you try to download a file that doesn't exist, the GET succeeds but writes and HTML error message rather than the data archive. The failure then manifests as failing to extract the archive, which I found misleading. (`raise_for_status` also immediately tells you the GET that failed.)